### PR TITLE
Fix example of individual files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ If you already have a TOC inserted by doctoc, it will automatically be updated b
 
 If you want to convert only specific files, do:
 ```shell
-docker run --rm -it -v /path/to/dir:/usr/src jorgeandrada/doctoc file.md
+docker run --entrypoint doctoc --rm -it -v /path/to/dir:/usr/src jorgeandrada/doctoc file.md --notitle
 ```
 
 ```
-docker run --rm -it -v /home/monino/Git/doctoc/:/usr/src jorgeandrada/doctoc README.md
+docker run --entrypoint doctoc --rm -it -v /home/monino/Git/doctoc/:/usr/src jorgeandrada/doctoc README.md --notitle
 ```
 
 ### Printing to stdout

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ If you already have a TOC inserted by doctoc, it will automatically be updated b
 
 If you want to convert only specific files, do:
 ```shell
-docker run --rm -it -v /path/to/file:/usr/src jorgeandrada/doctoc
+docker run --rm -it -v /path/to/dir:/usr/src jorgeandrada/doctoc file.md
 ```
 
 ```
-docker run --rm -it -v /home/monino/Git/doctoc/README.md:/usr/src jorgeandrada/doctoc
+docker run --rm -it -v /home/monino/Git/doctoc/:/usr/src jorgeandrada/doctoc README.md
 ```
 
 ### Printing to stdout


### PR DESCRIPTION
Otherwise "not a directory" error is thrown when docker attempts to mount the volume.

Overwrite entrypoint since i defaults to "." which will recurse.